### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy Backend to Render
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MERN-FS/server/security/code-scanning/1](https://github.com/MERN-FS/server/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only triggers an external deploy hook and does not interact with the repository contents or GitHub APIs, the safest minimal permissions are `contents: read`. This can be set at the workflow root level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the root level unless different jobs require different permissions. Edit the `.github/workflows/render-deploy.yml` file by inserting the following block after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
