### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.5",
     "multer": "^2.0.2",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "express-rate-limit": "^8.0.1"
   }
 }

--- a/routes/auth/auth-route.js
+++ b/routes/auth/auth-route.js
@@ -1,11 +1,21 @@
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 const {
   registerUser,
   loginUser,
 } = require("../../controllers/auth/auth-cotroller");
 const router = express.Router();
 
+// Limit repeated login attempts to 5 per 15min window per IP
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5,
+  message: "Too many login attempts from this IP, please try again after 15 minutes.",
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
 router.post("/register", registerUser);
-router.post("/login", loginUser);
+router.post("/login", loginLimiter, loginUser);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/MERN-FS/server/security/code-scanning/6](https://github.com/MERN-FS/server/security/code-scanning/6)

To address this issue, a rate limiter middleware (such as `express-rate-limit`) should be applied to the login route to restrict the number of requests a client can make within a specified window. The optimal fix is to require the `express-rate-limit`, define a limiter instance (for example, allowing 5 requests per 15 minutes per IP), and apply this limiter to the `/login` route only, rather than globally (since other routes may need different policies). This requires importing `express-rate-limit`, initializing a limiter, and using it as middleware specifically for the `/login` route.

All changes should be made in `routes/auth/auth-route.js`. The relevant code to add is:

- The import (`require('express-rate-limit')`)
- The limiter instance definition
- Modification of the `/login` route to include the limiter as middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
